### PR TITLE
remove extra tag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,6 @@ use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 
-/// <span
-///   class="module-item stab portability"
-///   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"
-/// ><code>attributes</code></span>
 /// Enables an async main function.
 ///
 /// # Examples
@@ -87,10 +83,6 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     result.into()
 }
 
-/// <span
-///   class="module-item stab portability"
-///   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"
-/// ><code>attributes</code></span>
 /// Enables an async test function.
 ///
 /// # Examples
@@ -128,10 +120,6 @@ pub fn test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     result.into()
 }
 
-/// <span
-///   class="module-item stab portability"
-///   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"
-/// ><code>attributes</code></span>
 /// Enables an async benchmark function.
 ///
 /// # Examples


### PR DESCRIPTION
Removes the extra doc tags; looks like it's been fixed in rustdoc. Thanks!