### PR TITLE
fix compile error with rustc 1.45.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,6 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![recursion_limit = "512"]
 
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;


### PR DESCRIPTION
fixing compile(lint) error with rustc 1.45.0

```
~/async-attributes$ cargo build
    Blocking waiting for file lock on build directory
   Compiling async-attributes v1.1.1 (/home/kazuk/async-attributes)
error: unused extern crate
  --> src/lib.rs:30:1
   |
30 | extern crate proc_macro;
   | ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
   |
note: the lint level is defined here
  --> src/lib.rs:26:45
   |
26 | #![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
   |                                             ^^^^^^^^^^^^^^^^
   = note: `#[forbid(unused_extern_crates)]` implied by `#[forbid(rust_2018_idioms)]`

error: aborting due to previous error

error: could not compile `async-attributes`.
```