### PR TITLE
Add async-spawner support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
-quote = "1.0"
+syn = { version = "1.0.48", features = ["full"] }
+quote = "1.0.7"
 
 [dev-dependencies]
-async-std = "0.99.5"
+async-spawner = "1.0.0"
+async-std = "1.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,15 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 #body
             }
 
+            {
+                use core::future::Future;
+                use core::pin::Pin;
+                fn spawn(future: Pin<Box<dyn Future<Output = ()> + Send>>) {
+                    async_std::task::spawn(future);
+                }
+                async_spawner::register_spawner(spawn);
+            }
+
             async_std::task::block_on(async {
                 main().await
             })


### PR DESCRIPTION
This allows writing async code that works with `#[async_std::main]` and `#[tokio::main]`.