### PR TITLE
Fix possible name collision in attribute output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub fn test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let result = quote! {
-        #[test]
+        #[::core::prelude::v1::test]
         #(#attrs)*
         #vis fn #name() #ret {
             async_std::task::block_on(async { #body })
@@ -159,7 +159,7 @@ pub fn bench(_attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let result = quote! {
-        #[bench]
+        #[::core::prelude::v1::bench]
         #(#attrs)*
         #vis fn #name(b: &mut test::Bencher) #ret {
             task::block_on(task::spawn(async {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,13 @@
+use async_attributes::test;
+
 #[async_attributes::test]
 async fn test() -> std::io::Result<()> {
     assert_eq!(2 * 2, 4);
+    Ok(())
+}
+
+#[test]
+async fn aliased_test() -> std::io::Result<()> {
+    assert!(true);
     Ok(())
 }


### PR DESCRIPTION
If another `test` or `bench` proc macro is in scope, the `#[test]` in
the output may not refer to Rust's own `#[test]` macro, but some other
macro.